### PR TITLE
update list of projects to look for to only show open ones

### DIFF
--- a/utilities/transfer-cards/main.go
+++ b/utilities/transfer-cards/main.go
@@ -25,7 +25,7 @@ var (
 
 func getProject(client *github.Client, ctx context.Context, projectName string) (*github.Project, error) {
 	log.Debugf("Attempting to find project %s for repo %s/%s", projectName, *repoOwner, *repoName)
-	projects, _, err := client.Repositories.ListProjects(ctx, *repoOwner, *repoName, &github.ProjectListOptions{State: "all"})
+	projects, _, err := client.Repositories.ListProjects(ctx, *repoOwner, *repoName, &github.ProjectListOptions{State: "open"})
 	if err != nil {
 		log.Errorf("Could not grab existing projects for %s/%s: %v", *repoOwner, *repoName, err)
 		os.Exit(1)


### PR DESCRIPTION
The number of projects in the repo has grown to more than one page of output. Need to just list the open projects so the results is only returned in 1 page.

Without this fix:
```
$ GITHUB_TOKEN=***7d7f5 ./transfer-cards --repo-name=release-tracking --dry-run 17.09.0-ce-rc2 17.09.0-ce-rc3
ERRO[0000] Source project '17.09.0-ce-rc2' not found in repo docker/release-tracking
```

With this fix:
```
$ GITHUB_TOKEN=***7d7f5 ./transfer-cards --repo-name=release-tracking --dry-run 17.09.0-ce-rc2 17.09.0-ce-rc3
INFO[0000] Source project: 17.09.0-ce-rc2, Dest Project: 17.09.0-ce-rc3 
INFO[0002] (dryrun) 17.09.0-ce-rc2/Triage -> 17.09.0-ce-rc3/Triage: #132 
INFO[0002] (dryrun) 17.09.0-ce-rc2/Triage -> 17.09.0-ce-rc3/Triage: #129 
INFO[0002] (dryrun) 17.09.0-ce-rc2/Triage -> 17.09.0-ce-rc3/Triage: #125 
INFO[0002] (dryrun) 17.09.0-ce-rc2/Cherry Pick -> 17.09.0-ce-rc3/Cherry Pick: #126 
INFO[0002] (dryrun) 17.09.0-ce-rc2/Cherry Pick -> 17.09.0-ce-rc3/Cherry Pick: #131 
INFO[0002] (dryrun) 17.09.0-ce-rc2/Cherry Pick -> 17.09.0-ce-rc3/Cherry Pick: #128 
INFO[0002] (dryrun) 17.09.0-ce-rc2/Cherry Pick -> 17.09.0-ce-rc3/Cherry Pick: #121 
INFO[0002] (dryrun) 17.09.0-ce-rc2/Cherry Pick -> 17.09.0-ce-rc3/Cherry Pick: #123 
INFO[0002] (dryrun) 17.09.0-ce-rc2/Cherry Pick -> 17.09.0-ce-rc3/Cherry Pick: #127 
INFO[0002] (dryrun) 17.09.0-ce-rc2/Cherry Pick -> 17.09.0-ce-rc3/Cherry Pick: #124 
INFO[0002] (dryrun) 17.09.0-ce-rc2/Cherry Pick -> 17.09.0-ce-rc3/Cherry Pick: #122
```

Signed-off-by: Andrew Hsu <andrewhsu@docker.com>